### PR TITLE
Use last block number on block sync

### DIFF
--- a/app/Synchronizer.js
+++ b/app/Synchronizer.js
@@ -71,7 +71,7 @@ class Synchronizer {
       }
     }
 
-    let daemon = async (findMissingBlock) => {
+    let daemon = async findMissingBlock => {
       if (_self.platform) {
         console.log('Synchronizer daemon - destroying past SyncPlatform');
         _self.platform.destroy();
@@ -92,7 +92,7 @@ class Synchronizer {
       );
     };
     // do-while fashion
-    daemon(true);
+    daemon(false);
     this.handler = setInterval(daemon, blocksSyncTime, false);
     console.log('Synchronizer.initialize - handler:', this.handler);
   }

--- a/app/Synchronizer.js
+++ b/app/Synchronizer.js
@@ -71,7 +71,7 @@ class Synchronizer {
       }
     }
 
-    let daemon = async () => {
+    let daemon = async (findMissingBlock) => {
       if (_self.platform) {
         console.log('Synchronizer daemon - destroying past SyncPlatform');
         _self.platform.destroy();
@@ -80,7 +80,8 @@ class Synchronizer {
       _self.platform = await SyncBuilder.build(
         pltfrm,
         _self.persistence,
-        sender
+        sender,
+        findMissingBlock
       );
       _self.platform.setPersistenceService();
       _self.platform.setBlocksSyncTime(syncconfig.sync.blocksSyncTime);
@@ -91,8 +92,8 @@ class Synchronizer {
       );
     };
     // do-while fashion
-    daemon();
-    this.handler = setInterval(daemon, blocksSyncTime);
+    daemon(true);
+    this.handler = setInterval(daemon, blocksSyncTime, false);
     console.log('Synchronizer.initialize - handler:', this.handler);
   }
 

--- a/app/persistence/fabric/MetricService.js
+++ b/app/persistence/fabric/MetricService.js
@@ -415,6 +415,11 @@ class MetricService {
 
     return this.sql.getRowsBySQlQuery(sqlQuery);
   }
+
+  async getLastBlockNumber(channel_genesis_hash) {
+    const sqlQuery = `SELECT blocknum FROM blocks WHERE channel_genesis_hash = '${channel_genesis_hash}'ORDER BY blocknum DESC LIMIT 1`
+    return this.sql.getRowsBySQlQuery(sqlQuery);
+  }
 }
 
 module.exports = MetricService;

--- a/app/platform/fabric/sync/FabricEvent.js
+++ b/app/platform/fabric/sync/FabricEvent.js
@@ -30,9 +30,20 @@ class FabricEvent {
   createChannelEventHub(channel) {
     // create channel event hub
     const eventHub = channel.newChannelEventHub(this.client.defaultPeer);
-    console.log(`FabricEvent[${this.rand}].createChannelEventHub - registering Block Event`);
+    console.log(
+      `FabricEvent[${
+        this.rand
+      }].createChannelEventHub - registering Block Event`
+    );
     let opt = {};
-    if (this.lastBlocknumPerChannel && this.lastBlocknumPerChannel[channel.getName()]) {
+    // DB가 비어있을때 (0번 블록부터 모두 가져와야 할 때) this.lastBlocknumPerChannel[channel.getName()]은 0이다.
+    // 따라서 조건식이 false가 되고 if문도 실행되지 않으면서 이벤트 리스너가 가장 최신 블록 하나만 가져오게 됨..
+    // if (this.lastBlocknumPerChannel && typeof this.lastBlocknumPerChannel[channel.getName()] !== "undefined")
+    // undefined 체킹 하면 0번(genesis) 블록 다음부터 가져오기 시작함 (리스너 등록할때 0번 블록을 걸러내고 있음)
+    if (
+      this.lastBlocknumPerChannel &&
+      this.lastBlocknumPerChannel[channel.getName()]
+    ) {
       opt['startBlock'] = this.lastBlocknumPerChannel[channel.getName()];
     }
     eventHub.registerBlockEvent(

--- a/app/platform/fabric/sync/SyncPlatform.js
+++ b/app/platform/fabric/sync/SyncPlatform.js
@@ -141,8 +141,18 @@ class SyncPlatform {
         return;
       }
 
+      // last blocknum of each channel_genesis_hash
+      let lastBlocknumPerChannel = {};
+      for (let [i, channelname] of Object.keys(this.client.client_config.channels).entries()) {
+        let channel_genesis_hash = this.client.getChannelGenHash(channelname);
+        let rows = await this.persistence.getMetricService().getLastBlockNumber(channel_genesis_hash);
+        let lastBlockNum = rows[0]['blocknum'];
+        lastBlocknumPerChannel[channelname] = lastBlockNum;
+      }
+      console.log(`lastBlocknumPerChannel:`, lastBlocknumPerChannel);
+
       // start event
-      this.eventHub = new FabricEvent(this.client, this.syncService);
+      this.eventHub = new FabricEvent(this.client, this.syncService, lastBlocknumPerChannel);
       await this.eventHub.initialize();
 
       // validating any missing block from the current client ledger

--- a/app/platform/fabric/sync/SyncPlatform.js
+++ b/app/platform/fabric/sync/SyncPlatform.js
@@ -143,16 +143,27 @@ class SyncPlatform {
 
       // last blocknum of each channel_genesis_hash
       let lastBlocknumPerChannel = {};
-      for (let [i, channelname] of Object.keys(this.client.client_config.channels).entries()) {
+      for (let [i, channelname] of Object.keys(
+        this.client.client_config.channels
+      ).entries()) {
         let channel_genesis_hash = this.client.getChannelGenHash(channelname);
-        let rows = await this.persistence.getMetricService().getLastBlockNumber(channel_genesis_hash);
-        let lastBlockNum = rows[0]['blocknum'];
+        let rows = await this.persistence
+          .getMetricService()
+          .getLastBlockNumber(channel_genesis_hash);
+        let lastBlockNum = 0;
+        if (rows.length != 0) {
+          lastBlockNum = rows[0]['blocknum'];
+        }
         lastBlocknumPerChannel[channelname] = lastBlockNum;
       }
       console.log(`lastBlocknumPerChannel:`, lastBlocknumPerChannel);
 
       // start event
-      this.eventHub = new FabricEvent(this.client, this.syncService, lastBlocknumPerChannel);
+      this.eventHub = new FabricEvent(
+        this.client,
+        this.syncService,
+        lastBlocknumPerChannel
+      );
       await this.eventHub.initialize();
 
       // validating any missing block from the current client ledger

--- a/app/platform/fabric/sync/SyncPlatform.js
+++ b/app/platform/fabric/sync/SyncPlatform.js
@@ -23,7 +23,7 @@ const explorer_mess = require('../../../common/ExplorerMessage').explorer;
 const config_path = path.resolve(__dirname, '../config.json');
 
 class SyncPlatform {
-  constructor(persistence, sender) {
+  constructor(persistence, sender, findMissingBlock) {
     this.rand = Math.random();
     this.network_name;
     this.client_name;
@@ -34,6 +34,7 @@ class SyncPlatform {
     this.syncService = new SyncService(this, this.persistence);
     this.blocksSyncTime = 60000;
     this.client_configs;
+    this.findMissingBlock = findMissingBlock;
   }
 
   async initialize(args) {

--- a/app/sync/SyncBuilder.js
+++ b/app/sync/SyncBuilder.js
@@ -6,10 +6,10 @@ const explorer_error = require('../common/ExplorerMessage').explorer.error;
 const ExplorerError = require('../common/ExplorerError');
 
 class SyncBuilder {
-  static async build(pltfrm, persistence, sender) {
+  static async build(pltfrm, persistence, sender, findMissingBlock) {
     if (pltfrm === explorer_const.PLATFORM_FABRIC) {
       const SyncPlatform = require('../platform/fabric/sync/SyncPlatform');
-      const platform = new SyncPlatform(persistence, sender);
+      const platform = new SyncPlatform(persistence, sender, findMissingBlock);
       return platform;
     }
     throw new ExplorerError(explorer_error.ERROR_1005, pltfrm);


### PR DESCRIPTION
## Changes
- never use `findMissingBlockNumber()`
  - causes slow DB query on large block heights
- use new `getLastBlockNumber()`
  - uses last block number on DB as starting block number for event listener registration
## Unattended Issues
- Only receives latest block on blockchain if DB is empty (clean start)
  - See FabricEvent.js:39